### PR TITLE
Pip dependency manager compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea

--- a/Dependencies.txt
+++ b/Dependencies.txt
@@ -1,2 +1,0 @@
-Python 3.7
-pip install colorama

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Python 3.7
+colorama


### PR DESCRIPTION
Renamed `Dependencies.txt` to `requirements.txt` to handle pip dependency manager commands.